### PR TITLE
Making >mute recognise when no users are muted

### DIFF
--- a/GenericBot/CommandModules/ModCommands.cs
+++ b/GenericBot/CommandModules/ModCommands.cs
@@ -220,7 +220,7 @@ namespace GenericBot.CommandModules
                 if (dbUsers.Count > 5)
                 {
                     string info =
-                        $"Found `{dbUsers.Count}` users. Their first stored usernames are:\n{dbUsers.Select(u => $"{u.Usernames.First().Escape()} (`{user.ID}`)").ToList().SumAnd()}" +
+                        $"Found `{dbUsers.Count}` users. Their first stored usernames are:\n{dbUsers.Select(u => $"{u.Usernames.First().Escape()} (`{u.ID}`)").ToList().SumAnd()}" +
                         $"\nTry using more precise search parameters";
 
                     foreach (var str in info.SplitSafe(','))
@@ -478,7 +478,16 @@ namespace GenericBot.CommandModules
                     }
                 }
 
-                string res = "Succesfully muted " + mutedUsers.Select(u => u.Mention).ToList().SumAnd();
+                string res;
+
+                if(mutedUsers.Count > 0) 
+                {
+                    res = "Succesfully muted " + mutedUsers.Select(u => u.Mention).ToList().SumAnd();
+                }
+                else
+                {
+                    res = "Could not find that user";
+                }
 
                 await msg.ReplyAsync(res);
 


### PR DESCRIPTION
Fixes https://github.com/MasterChief-John-117/GenericBot/issues/28 

also an issue when more than 5 users are found in >find because you had user instead of u when building the list of them, fixed that for ya too :P