### PR TITLE
Made rolestore info text add before printing

### DIFF
--- a/GenericBot/CommandModules/RoleCommands.cs
+++ b/GenericBot/CommandModules/RoleCommands.cs
@@ -57,12 +57,12 @@ namespace GenericBot.CommandModules
                     message += $"`{role.Name}`, ";
                 }
                 message = message.Trim(' ', ',');
+                message += $"\n You can also use `{prefix}rolestore save` to backup your assigned roles";
 
                 foreach (var str in message.SplitSafe())
                 {
                     await msg.ReplyAsync(str);
                 }
-                message += $"\n You can also use `{prefix}rolestore save` to backup your assigned roles";
             };
 
             RoleCommands.Add(UserRoles);


### PR DESCRIPTION
Move the line of code that adds the rolestore command info to the string to be sent above the print line