### PR TITLE
Fix multiple issues with the lookup commands

### DIFF
--- a/GenericBot/CommandModules/CustomCommandModule.cs
+++ b/GenericBot/CommandModules/CustomCommandModule.cs
@@ -37,7 +37,7 @@ namespace GenericBot.CommandModules
                     {
                         rawResponse += $"`{cmd.Name}`: {cmd.Response.SafeSubstring(100)}\nDelete: `{cmd.Delete}`\n\n";
                     }
-                    foreach (var resp in rawResponse.SplitSafe('\n'))
+                    foreach (var resp in rawResponse.MessageSplit('\n'))
                     {
                         await context.Message.ReplyAsync(resp);
                     }

--- a/GenericBot/CommandModules/InfoModule.cs
+++ b/GenericBot/CommandModules/InfoModule.cs
@@ -207,7 +207,7 @@ namespace GenericBot.CommandModules
                     return;
                 }
 
-                foreach (var str in commandList.SplitSafe())
+                foreach (var str in commandList.MessageSplit())
                 {
                     await context.Message.ReplyAsync(str);
                 }

--- a/GenericBot/CommandModules/LookupModule.cs
+++ b/GenericBot/CommandModules/LookupModule.cs
@@ -77,7 +77,7 @@ namespace GenericBot.CommandModules
                         $"Found `{foundUsers.Count}` users. Their first stored usernames are:\n{foundUsers.Select(u => $"{u.Usernames.First().Escape()} (`{u.Id}`)").ToList().SumAnd()}" +
                         $"\nTry using more precise search parameters";
 
-                    foreach (var str in info.SplitSafe(','))
+                    foreach (var str in info.MessageSplit(','))
                     {
                         await context.Message.ReplyAsync(str.TrimStart(','));
                     }
@@ -184,7 +184,7 @@ namespace GenericBot.CommandModules
                 }
                 
                 var usernames = user.Usernames.Distinct().Select(n => $"`{n.Replace("`", "'")}`").ToList().SumAnd();
-                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {usernames}".SplitSafe()) 
+                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {usernames}".MessageSplit()) 
                     await context.Message.ReplyAsync(s);
             };
             commands.Add(names);
@@ -210,7 +210,7 @@ namespace GenericBot.CommandModules
                 }
                 
                 var nicknames = user.Nicknames.Distinct().Select(n => $"`{n.Replace("`", "'")}`").ToList().SumAnd();
-                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {nicknames}".SplitSafe()) 
+                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {nicknames}".MessageSplit(',')) 
                     await context.Message.ReplyAsync(s);
             };
             commands.Add(nicksCmd);

--- a/GenericBot/CommandModules/LookupModule.cs
+++ b/GenericBot/CommandModules/LookupModule.cs
@@ -184,7 +184,7 @@ namespace GenericBot.CommandModules
                 }
                 
                 var usernames = user.Usernames.Distinct().Select(n => $"`{n.Replace("`", "'")}`").ToList().SumAnd();
-                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {usernames}".MessageSplit()) 
+                foreach (var s in $"<@!{user.Id}> has had the following nicknames: {usernames}".MessageSplit(',')) 
                     await context.Message.ReplyAsync(s);
             };
             commands.Add(names);

--- a/GenericBot/CommandModules/LookupModule.cs
+++ b/GenericBot/CommandModules/LookupModule.cs
@@ -154,7 +154,7 @@ namespace GenericBot.CommandModules
                         eb.AddField($"Past nicknames ({dbUser.Nicknames.Count})", nicks.Truncate(1024, $"\u2026 (`{Core.GetPrefix(context)}nicks {dbUser.Id}`)"));
                     
                     if ((dbUser.Warnings?.Count ?? 0) > 0)
-                        eb.AddField($"Warnings ({dbUser.Warnings})", warnings.Truncate(1024, $"\u2026 (`{Core.GetPrefix(context)}warns {dbUser.Id}`)"));
+                        eb.AddField($"Warnings ({dbUser.Warnings.Count})", warnings.Truncate(1024, $"\u2026 (`{Core.GetPrefix(context)}warns {dbUser.Id}`)"));
                     
                     eb.WithDescription(description);
 

--- a/GenericBot/CommandModules/RoleModule.cs
+++ b/GenericBot/CommandModules/RoleModule.cs
@@ -59,7 +59,7 @@ namespace GenericBot.CommandModules
                 message = message.Trim(' ', ',', '\n');
                 //message += $"\n You can also use `{prefix}rolestore save` to backup your assigned roles";
 
-                foreach (var str in message.SplitSafe())
+                foreach (var str in message.MessageSplit())
                 {
                     await context.Message.ReplyAsync(str);
                 }
@@ -224,7 +224,7 @@ namespace GenericBot.CommandModules
                     message += $"{role.Name} (`{role.Id}`)\n";
                 }
 
-                foreach (var str in message.SplitSafe())
+                foreach (var str in message.MessageSplit())
                 {
                     await context.Message.ReplyAsync(str);
                 }
@@ -254,7 +254,7 @@ namespace GenericBot.CommandModules
                     }
                 }
 
-                foreach (var str in result.SplitSafe('\n'))
+                foreach (var str in result.MessageSplit('\n'))
                 {
                     await context.Message.ReplyAsync(str);
                 }

--- a/GenericBot/Extensions.cs
+++ b/GenericBot/Extensions.cs
@@ -148,27 +148,40 @@ namespace GenericBot
             return list[new Random().Next(0, list.Count - 1)];
         }
 
-        public static List<string> SplitSafe(this string input, char spl = ' ')
+        /**
+         * Splits a long message to smaller messages of a given maximum length each on a specific character.
+         *
+         * This function will ensure the message splits *only* happen on the given split character, which can be used
+         * to prevent breaking markup across split points by passing a delimiter known to be outside any markup.
+         */
+        public static List<string> MessageSplit(this string input, char delimiter = ' ', int maxLineLength = 1800)
         {
             List<string> output = new List<string>();
-            var strings = input.Split(spl);
+            var stringComponents = input.Split(delimiter);
 
-            string temp = "";
-            foreach (var s in strings)
+            var accumulator = "";
+            for (var i = 0; i < stringComponents.Length; i++)
             {
-                if (temp.Length + s.Length < 1800)
+                var currentSubstring = stringComponents[i];
+                
+                if (accumulator.Length + currentSubstring.Length < maxLineLength)
                 {
-                    temp += spl + s;
+                    accumulator += currentSubstring;
+                    
+                    // If this isn't the last substring, we add a delimiter.
+                    if (i < stringComponents.Length - 1) accumulator += delimiter;
                 }
                 else
                 {
-                    output.Add(temp);
-                    temp = s;
+                    // Finish off the accumulator we have, and start a new one containing the current substring
+                    output.Add(accumulator);
+                    accumulator = currentSubstring;
                 }
             }
-
-            output.Add(temp);
-
+            
+            // We're done, add whatever's left in the accumulator to the last line (or in single-line cases, all our
+            // input text), and return it.
+            output.Add(accumulator);
             return output;
         }
 


### PR DESCRIPTION
This fixes two issues with the current implementation of the lookup commands:

* \>whois prints a generic list identifier instead of the warning count
* \>nicks and >names don't split properly on commas

I've also rewritten the SplitSafe function to be clearer in the implementation and handle edge cases better.