### PR TITLE
Add Trusted Role mechanism to GenericBot

### DIFF
--- a/GenericBot/CommandModules/ConfigModule.cs
+++ b/GenericBot/CommandModules/ConfigModule.cs
@@ -38,7 +38,9 @@ namespace GenericBot.CommandModules
                     $"    Role Id: `{_guildConfig.VerifiedRole}`\n" +
                     $"    Message: Do `{Core.GetPrefix(context)}config verification message` to see the message\n" +
                     $"Points: {_guildConfig.PointsEnabled}\n" +
-                    $"Auto Roles: `{JsonConvert.SerializeObject(_guildConfig.AutoRoleIds)}`";
+                    $"Auto Roles: `{JsonConvert.SerializeObject(_guildConfig.AutoRoleIds)}`" +
+                    $"Trusted Role Id: `{_guildConfig.TrustedRoleId}`" +
+                    $"Trusted Role Point Threshold: `{_guildConfig.TrustedRolePointThreshold}`";
 
                     await context.Message.ReplyAsync(currentConfig);
                 }
@@ -646,6 +648,39 @@ namespace GenericBot.CommandModules
 
                 #endregion Points
 
+                #region Trusted Role
+
+                else if (context.Parameters.FirstOrDefault().Equals("trustedrole"))
+                {
+                    context.Parameters.RemoveAt(0);
+                    if (context.Parameters.Count() < 2)
+                    {
+                        await context.Message.ReplyAsync("Please provide an action and a numeric value.");
+                    }
+
+                    var command = context.Parameters[0];
+                    var argument = context.Parameters[1];
+                    if (ulong.TryParse(argument, out ulong argumentAsLong))
+                    {
+                        switch (command)
+                        {
+                            case "setrole":
+                                _guildConfig.TrustedRoleId = argumentAsLong;
+                                break;
+                            case "threshold":
+                                _guildConfig.TrustedRolePointThreshold = argumentAsLong;
+                                break;
+                            default:
+                                await context.Message.ReplyAsync($"Unknown property `{command}`.");
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        context.Message.ReplyAsync($"Invalid argument `{argument}`.");
+                    }
+                }
+                #endregion
 
                 else await context.Message.ReplyAsync($"Unknown property `{context.Parameters[0]}`.");
 

--- a/GenericBot/Entities/GuildConfig.cs
+++ b/GenericBot/Entities/GuildConfig.cs
@@ -41,6 +41,8 @@ namespace GenericBot.Entities
         public ulong JoinMessageChannelId { get; set; }
         public AntiSpamLevel AntispamLevel { get; set; }
         public bool PointsEnabled { get; set; }
+        public ulong TrustedRoleId { get; set; }
+        public ulong TrustedRolePointThreshold { get; set; }
 
         public GuildConfig(ulong id)
         {
@@ -54,6 +56,8 @@ namespace GenericBot.Entities
             UserRoles = new Dictionary<string, List<ulong>>();
             AutoRoleIds = new List<ulong>();
             PointsEnabled = false;
+            TrustedRoleId = 0;
+            TrustedRolePointThreshold = 0;
         }
     }
 

--- a/GenericBot/EventHandlers/MessageEventHandler.cs
+++ b/GenericBot/EventHandlers/MessageEventHandler.cs
@@ -70,6 +70,18 @@ namespace GenericBot
             {
                 var dbUser = Core.GetUserFromGuild(parameterMessage.Author.Id, parameterMessage.GetGuild().Id);
                 dbUser.IncrementPointsAndMessages();
+
+                var dbGuild = Core.GetGuildConfig(parameterMessage.GetGuild().Id);
+                if (dbGuild.TrustedRoleId != 0 && dbUser.Points > dbGuild.TrustedRolePointThreshold)
+                {
+                    var guild = Core.DiscordClient.GetGuild(dbGuild.Id);
+                    var guildUser = guild.GetUser(dbUser.Id);
+                    if (!guildUser.Roles.Any(sr => sr.Id == dbGuild.TrustedRoleId))
+                    {
+                        guildUser.AddRoleAsync(guild.GetRole(dbGuild.TrustedRoleId));
+                    }
+                }
+
                 Core.SaveUserToGuild(dbUser, parameterMessage.GetGuild().Id);
             }
             catch (Exception e)


### PR DESCRIPTION
Hello from ProbabyNotLeif#0001, from CasCon!

I've implemented a 'trusted role' setting, which would enable server administrators to gate functionality behind a role that is automatically assigned after a preset activity period has been eclipsed. This uses the existing points mechanism, in order to try and guard against abuse.

The trusted role is configured with:
setrole <snowflake>, to set the trusted role.
threshold <integer>, to set the threshold.

Tested in a private server.